### PR TITLE
Support for building on VisualStudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+Note on Windows build
+=====================
+
+Current version builds on Windows 7, provided that the files pcre.h and pcre3.lib are available under C:/Windows/system.
+
+Look on [http://www.airesoft.co.uk/pcre](www.airesoft.co.uk) for a prebuilt version of PCRE.
+
+Check and edit the mrbgem.rake accordingly.

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,6 +1,13 @@
 MRuby::Gem::Specification.new('mruby-pcre-regexp') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
-
-  spec.linker.libraries << ['pcre']
+  
+  case RUBY_PLATFORM
+  when /mingw|mswin/
+    spec.linker.libraries << ['pcre3', 'Shlwapi']
+    spec.cc.include_paths += ["C:/Windows/system"]
+    spec.linker.library_paths += ["C:/Windows/system"]
+  else
+    spec.linker.libraries << ['pcre']
+  end
 end


### PR DESCRIPTION
Some source edits so that it also builds and works on Windows/VisualStudio.
- `mrbgem.rake` amended so to have different include/libpaths for win and *nix.
- Source file amended by moving variables declaration at the beginning of each function (required by the silly MS compiler)
- Added a macro for mapping VS StrChr <-> strchr
