### PR TITLE
Update mruby_pcre_regexp.c

### DIFF
--- a/src/mruby_pcre_regexp.c
+++ b/src/mruby_pcre_regexp.c
@@ -103,7 +103,7 @@ pcre_regexp_initialize_copy(mrb_state *mrb, mrb_value copy) {
 static mrb_value
 pcre_regexp_match(mrb_state *mrb, mrb_value self) {
   const char *str;
-  char global_match[3];
+  char global_match[5];
   mrb_value regexp;
   struct mrb_pcre_regexp *reg;
   int i;


### PR DESCRIPTION
I received this error:
```
mruby_pcre_regexp.c:140:7: note: 'sprintf' output between 3 and 5 bytes into a destination of size 3
       sprintf(global_match, "$%i", i);
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```